### PR TITLE
fix: add missing call to ledstrip.begin()

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=Leaphy Extra Extension
-version=0.0.21
+version=0.0.22
 author=Leaphy Robotics
 maintainer=Leaphy Robotics <paul@leaphy.nl>
 sentence=Provides Extra functionality to Leaphy robots

--- a/src/ledstrip.cpp
+++ b/src/ledstrip.cpp
@@ -1,6 +1,7 @@
 #include "ledstrip.h"
 
 LEDSTRIP::LEDSTRIP(uint8_t p, uint16_t tot){
+  strip.begin();
   strip.setPin(p);
   strip.updateLength(tot);
   pinMode(pin, OUTPUT);


### PR DESCRIPTION
Adafruit Neopixel now requires strip.begin(), added